### PR TITLE
Fix typo in role dropdown option

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                             <select id="role_assign" name="role_assign" class="form-control">
                                 <option selected>Choose...</option>
                                 <option>admin</option>
-                                <option>permenent</option>
+                                <option>permanent</option>
                                 <option>temporary</option>
                             </select>
                         </div>


### PR DESCRIPTION
## Summary
- correct `permanent` role option

## Testing
- `grep -n permanent -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6843588c1178832cbcd6440753d83c35