### PR TITLE
Add Hardhat test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ $RECYCLE.BIN/
 
 #Project Folder
 .idea
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # OPEN
+
+This repository contains Solidity contracts and a basic Hardhat setup for compilation and testing.
+
+## Running Tests
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Run the tests:
+
+```bash
+npx hardhat test
+```
+
+The provided tests are placeholders and can be extended to cover the Solidity contracts in this repository.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,10 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: ".",
+    tests: "test"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "open",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "npx hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "hardhat": "^2.20.2"
+  }
+}

--- a/test/sample-test.js
+++ b/test/sample-test.js
@@ -1,0 +1,7 @@
+const { expect } = require("chai");
+
+describe("Contracts", function () {
+  it("placeholder test", async function () {
+    expect(true).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Hardhat with package.json and config
- add placeholder test
- document test instructions
- ignore node_modules in `.gitignore`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx hardhat test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68435ac8253c832ca7754679a8a41607