### PR TITLE
refactor: streamline ownership tracking

### DIFF
--- a/contracts/AssetTrackerOptimized.sol
+++ b/contracts/AssetTrackerOptimized.sol
@@ -41,7 +41,6 @@ contract AssetTrackerOptimized {
 
     // State variables
     mapping(string => Asset) private _assets;
-    mapping(address => mapping(string => bool)) private _ownerAssets;
     mapping(address => uint256) private _assetCounts;
     
     // Total asset count for statistics
@@ -104,8 +103,7 @@ contract AssetTrackerOptimized {
             manufacturer: manufacturer
         });
 
-        // Update ownership tracking
-        _ownerAssets[msg.sender][uuid] = true;
+        // Update ownership count
         _assetCounts[msg.sender]++;
         _totalAssets++;
 
@@ -124,17 +122,13 @@ contract AssetTrackerOptimized {
         assetExists(uuid)
         onlyAssetOwner(uuid)
     {
-        address from = msg.sender;
-        
+        address from = _assets[uuid].owner;
+
         // Update ownership
         /* solhint-disable not-rely-on-time */
         _assets[uuid].owner = to;
         _assets[uuid].timestamp = uint96(block.timestamp);
-        
-        // Update tracking mappings
-        _ownerAssets[from][uuid] = false;
-        _ownerAssets[to][uuid] = true;
-        
+
         // Update counters
         _assetCounts[from]--;
         _assetCounts[to]++;
@@ -185,7 +179,7 @@ contract AssetTrackerOptimized {
         view
         returns (bool)
     {
-        return _ownerAssets[owner][uuid];
+        return _assets[uuid].owner == owner;
     }
 
     /**

--- a/test/AssetTrackerOptimized.test.js
+++ b/test/AssetTrackerOptimized.test.js
@@ -35,6 +35,8 @@ describe('AssetTrackerOptimized', function () {
       expect(asset.manufacturer).to.equal(manufacturer);
 
       expect(await assetTrackerOptimized.isOwnerOf(owner.address, uuid)).to.be.true;
+
+      expect(await assetTrackerOptimized.getAssetCount(owner.address)).to.equal(1);
     });
 
     it('Should reject creation of duplicate assets', async function () {
@@ -85,6 +87,9 @@ describe('AssetTrackerOptimized', function () {
 
       expect(await assetTrackerOptimized.isOwnerOf(owner.address, testAsset.uuid)).to.be.false;
       expect(await assetTrackerOptimized.isOwnerOf(addr1.address, testAsset.uuid)).to.be.true;
+
+      expect(await assetTrackerOptimized.getAssetCount(owner.address)).to.equal(0);
+      expect(await assetTrackerOptimized.getAssetCount(addr1.address)).to.equal(1);
     });
 
     it('Should reject transfer of non-existent asset', async function () {


### PR DESCRIPTION
## Summary
- remove _ownerAssets mapping and rely on asset.owner
- adjust transfer logic to update counts via asset owner
- add tests verifying asset count after creation and transfer

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*
- `npm run analyze:performance` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68961381cf28832ca5021e028645e239